### PR TITLE
use the configmap standard to document the kind registry

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -24,7 +24,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: tiltdev/circleci-kind:v1.0.0
+      - image: tiltdev/circleci-kind:v1.2.0
 
     steps:
       - setup_remote_docker
@@ -36,15 +36,15 @@ The `circleci-kind` image has all the tools you need to set up
 and talk to the cluster. You can build on this image with:
 
 ```
-FROM tiltdev/circleci-kind:v1.0.0
+FROM tiltdev/circleci-kind:v1.2.0
 ```
 
 Or copy out the helper scripts:
 
 ```
-COPY --from=tiltdev/circleci-kind:v1.0.0 /usr/local/bin/start-portforward-service.sh /usr/local/bin/
-COPY --from=tiltdev/circleci-kind:v1.0.0 /usr/local/bin/portforward.sh /usr/local/bin/
-COPY --from=tiltdev/circleci-kind:v1.0.0 /usr/local/bin/with-kind-cluster.sh /usr/local/bin/
+COPY --from=tiltdev/circleci-kind:v1.2.0 /usr/local/bin/start-portforward-service.sh /usr/local/bin/
+COPY --from=tiltdev/circleci-kind:v1.2.0 /usr/local/bin/portforward.sh /usr/local/bin/
+COPY --from=tiltdev/circleci-kind:v1.2.0 /usr/local/bin/with-kind-cluster.sh /usr/local/bin/
 ```
 
 See [Dockerfile](Dockerfile) for instructions on how to add these tools to

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: tiltdev/circleci-kind:v1.1.0
+      - image: tiltdev/circleci-kind:v1.2.0
 
     steps:
       - setup_remote_docker

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ that inspired a lot of this work.
 
 The Kind team ran with this, writing up documentation and hooks for how to [set up a local registry](https://kind.sigs.k8s.io/docs/user/local-registry/) with Kind.
 
-This repo modifies the Kind team's script to annotate the nodes with information about the local registry, 
-so that Tilt can find it.
+This repo modifies the Kind team's script to apply the local registry configmap, so that tools
+like Tilt can discover the local-registry. This protocol is a [Kubernetes Enhancement Proposal](https://github.com/kubernetes/enhancements/issues/1755).
 
 Tested on Kind 0.7.0 and Kind 0.8.0
 

--- a/kind-with-registry.sh
+++ b/kind-with-registry.sh
@@ -56,9 +56,17 @@ containerdConfigPatches:
     endpoint = ["http://${reg_host}:${reg_port}"]
 EOF
 
-for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
-  kubectl annotate node "${node}" tilt.dev/registry=localhost:${reg_port};
-done
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
 
 if [ "${kind_network}" != "bridge" ]; then
   containers=$(docker network inspect ${kind_network} -f "{{range .Containers}}{{.Name}} {{end}}")


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/configmap:

9e0d2d3a0c8d48213a3d2d889a67845e37e85341 (2020-07-28 19:00:04 -0400)
use the configmap standard to document the kind registry

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics