### PR TITLE
use alpine/socat instead of bobrik/socat

### DIFF
--- a/.circleci/start-portforward-service.sh
+++ b/.circleci/start-portforward-service.sh
@@ -31,4 +31,4 @@ set -o errtrace
 docker run -d -it \
     --name portforward --net=host \
     --entrypoint /bin/sh \
-    bobrik/socat -c "while true; do sleep 1000; done"
+    alpine/socat -c "while true; do sleep 1000; done"


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/socat:

5d76ccc9e75f9ae3c2e7eb20d3c4c870cd1a0032 (2020-10-14 12:17:23 -0400)
use alpine/socat instead of bobrik/socat

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics