### PR TITLE
minor bug: even if the public port changes, the container port is still 5000

### DIFF
--- a/kind-with-registry.sh
+++ b/kind-with-registry.sh
@@ -53,7 +53,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_host}:${reg_port}"]
+    endpoint = ["http://${reg_host}:5000"]
 EOF
 
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ports:

2e9727e12c652e55dfc8e1f15826642c1be4ec4f (2020-10-23 17:26:34 -0400)
minor bug: even if the public port changes, the container port is still 5000
noticed this when playing around with different public ports

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics