### PR TITLE
Update kind-with-registry.sh to allow custom image

### DIFF
--- a/kind-with-registry.sh
+++ b/kind-with-registry.sh
@@ -21,6 +21,11 @@ set -o errexit
 
 # desired cluster name; default is "kind"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+KIND_CLUSTER_OPTS="--name ${KIND_CLUSTER_NAME}"
+
+if [ -n "${KIND_CLUSTER_IMAGE}" ]; then
+  KIND_CLUSTER_OPTS="${KIND_CLUSTER_OPTS} --image ${KIND_CLUSTER_IMAGE}"
+fi
 
 kind_version=$(kind version)
 kind_network='kind'
@@ -47,7 +52,7 @@ fi
 echo "Registry Host: ${reg_host}"
 
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+cat <<EOF | kind create cluster ${KIND_CLUSTER_OPTS} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:


### PR DESCRIPTION
Thanks for providing this script, it's great for speeding up development!

I had to modify it so that I could pass it in a custom kind image so that I can test against a similar k8s API version that matches our infra. I've tested it out with and with the ENV variable being passed in and it seems to work.

```shell
❯ kind version                                                     33.8s  Mon Mar 22 15:10:41 2021
kind v0.10.0 go1.15.7 darwin/amd64
```

With ENV flag:
```shell
❯ KIND_CLUSTER_IMAGE='kindest/node:v1.15.12' bash kind-with-registry.sh
Registry Host: kind-registry
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.15.12) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
configmap/local-registry-hosting created
```

Without ENV:
```shell
❯ bash kind-with-registry.sh                                      1225ms  Mon Mar 22 15:13:52 2021
Registry Host: kind-registry
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.20.2) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
configmap/local-registry-hosting created
```